### PR TITLE
写入 `csv` 文件编码头标识格式以避免中文乱码

### DIFF
--- a/utils/csv.go
+++ b/utils/csv.go
@@ -75,7 +75,8 @@ func ExportCsv(data []CloudflareIPData) {
 		return
 	}
 	defer fp.Close()
-	w := csv.NewWriter(fp) //创建一个新的写入文件流
+	_, _ = fp.Write([]byte{0xef, 0xbb, 0xbf}) // UTF-8 BOM 头
+	w := csv.NewWriter(fp)                    // 创建一个新的写入文件流
 	_ = w.Write([]string{"IP 地址", "已发送", "已接收", "丢包率", "平均延迟", "下载速度 (MB/s)"})
 	_ = w.WriteAll(convertToString(data))
 	w.Flush()


### PR DESCRIPTION
默认输出 csv 时未写入编码格式，在 `microsoft excel` 下会出现中文乱码的情况，写入此文件头即可修复

#142