### PR TITLE
修复某些情况下测速数值过大的问题

### DIFF
--- a/task/download.go
+++ b/task/download.go
@@ -170,7 +170,11 @@ func downloadHandler(ip *net.IPAddr) float64 {
 			if err != io.EOF { // 文件下载完了，或因网络等问题导致链接中断，则退出循环（终止测速）
 				break
 			}
-			e.Add(float64(contentRead-lastContentRead) / (float64(nextTime.Sub(currentTime)) / float64(timeSlice)))
+			// 获取上个时间片
+			last_time_slice := timeStart.Add(timeSlice * time.Duration(timeCounter-1))
+			// 下载数据量 / (用当前时间 - 上个时间片/ 时间片)
+			e.Add(float64(contentRead-lastContentRead) / (float64(currentTime.Sub(last_time_slice)) / float64(timeSlice)))
+
 		}
 		contentRead += int64(bufferRead)
 	}

--- a/task/download.go
+++ b/task/download.go
@@ -167,13 +167,14 @@ func downloadHandler(ip *net.IPAddr) float64 {
 		}
 		bufferRead, err := response.Body.Read(buffer)
 		if err != nil {
-			if err != io.EOF { // 文件下载完了，或因网络等问题导致链接中断，则退出循环（终止测速）
-				break
-			}
 			// 获取上个时间片
 			last_time_slice := timeStart.Add(timeSlice * time.Duration(timeCounter-1))
 			// 下载数据量 / (用当前时间 - 上个时间片/ 时间片)
 			e.Add(float64(contentRead-lastContentRead) / (float64(currentTime.Sub(last_time_slice)) / float64(timeSlice)))
+
+			if err == io.EOF { // 文件下载完了，或因网络等问题导致链接中断，则退出循环（终止测速）
+				break
+			}
 
 		}
 		contentRead += int64(bufferRead)


### PR DESCRIPTION
先说下 `CloudflareSpeedTest`的测速方法

1. 创建一个 移动加权平均数 `e`

2. 根据`Timeout` 切分成多个均匀的时间点，比如默认的时间点的间隔是 100ms

3. 那么时间点分布就像是 `0 .. 100 .. 200 .. 300 .. 400 .. 500` 

4. 在超过时间点后，将此时间片内的增量数据添加到 `e` 内

5. 有种特殊情况是当下载已经完成，还没到达下一个时间点的时候

6. 会将 增量数量 / ((下个时间点 - 当前时间) / 时间片)

7. 问题出在 **下个时间点 - 当前时间**，如果当前时间是 492ms, 而下一个时间点是 500ms，那么得出时间差是 8ms ，相当于计算的是 8ms 内增量数据

8. 正确的算法应该是 **当前时间 - 上个时间点** 得出是 492 - 400 = 92ms ，计算的是92ms 内的增量数据

所以在距离下个时间点*非常接近*的时候，就会导致测试的数字膨胀过大

### 其他bug
还有段这样的代码
```golang
			if err != io.EOF { // 文件下载完了，或因网络等问题导致链接中断，则退出循环（终止测速）
				break
			}
```
按照原本的意思应该是当遇到 `io.EOF` 就退出才对，这也顺便改正过来了

