### PR TITLE
fix 丢包率格式为百分号形式

### DIFF
--- a/utils/csv.go
+++ b/utils/csv.go
@@ -59,7 +59,7 @@ func (cf *CloudflareIPData) toString() []string {
 	result[0] = cf.IP.String()
 	result[1] = strconv.Itoa(cf.Sended)
 	result[2] = strconv.Itoa(cf.Received)
-	result[3] = strconv.FormatFloat(float64(cf.getRecvRate()), 'f', 2, 32)
+	result[3] = strconv.FormatFloat(float64(cf.getRecvRate()*100), 'f', 2, 32) + "%"
 	result[4] = strconv.FormatFloat(cf.Delay.Seconds()*1000, 'f', 2, 32)
 	result[5] = strconv.FormatFloat(cf.DownloadSpeed/1024/1024, 'f', 2, 32)
 	return result


### PR DESCRIPTION
开发大大你好，目前的丢包率是以单纯的小数，不是很直观
我做了一个小修改，效果如下:
<img width="540" alt="image" src="https://user-images.githubusercontent.com/14249262/228721749-04b34eba-c867-42e8-9742-6e445b9f022e.png">
这样感觉更加直观，希望大大能接受