### PR TITLE
fix: close http connections when each ip test ended

### DIFF
--- a/task/download.go
+++ b/task/download.go
@@ -155,6 +155,7 @@ func downloadHandler(ip *net.IPAddr) (float64, string) {
 			return nil
 		},
 	}
+	defer client.CloseIdleConnections()
 	req, err := http.NewRequest("GET", URL, nil)
 	if err != nil {
 		if utils.Debug { // 调试模式下，输出更多信息

--- a/task/httping.go
+++ b/task/httping.go
@@ -37,6 +37,7 @@ func (p *Ping) httping(ip *net.IPAddr) (int, time.Duration, string) {
 			return http.ErrUseLastResponse // 阻止重定向
 		},
 	}
+	defer hc.CloseIdleConnections()
 
 	// 先访问一次获得 HTTP 状态码 及 地区码
 	var colo string


### PR DESCRIPTION
在使用特定 url （如`https://speed.cloudflare.com/__down?bytes=300000000`）时会导致未使用的连接长时间占用端口但无法自动释放。

before:

<img width="2766" height="1904" alt="image" src="https://github.com/user-attachments/assets/50f79a2a-8619-40d2-b897-f8ce13c86feb" />

after:

<img width="2773" height="1911" alt="image" src="https://github.com/user-attachments/assets/60d9b6b2-c048-474c-8311-5d9f7fba2a1f" />
