### PR TITLE
Fix delay filtering across loss-rate groups

### DIFF
--- a/utils/csv.go
+++ b/utils/csv.go
@@ -112,8 +112,8 @@ func (s PingDelaySet) FilterDelay() (data PingDelaySet) {
 		return s
 	}
 	for _, v := range s {
-		if v.Delay > InputMaxDelay { // 平均延迟上限，延迟大于条件最大值时，后面的数据都不满足条件，直接跳出循环
-			break
+		if v.Delay > InputMaxDelay { // 结果优先按丢包率排序，后续数据仍可能满足延迟条件
+			continue
 		}
 		if v.Delay < InputMinDelay { // 平均延迟下限，延迟小于条件最小值时，不满足条件，跳过
 			continue

--- a/utils/csv_test.go
+++ b/utils/csv_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"net"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestFilterDelayChecksEveryLossRateGroup(t *testing.T) {
+	originalMaxDelay, originalMinDelay := InputMaxDelay, InputMinDelay
+	t.Cleanup(func() {
+		InputMaxDelay, InputMinDelay = originalMaxDelay, originalMinDelay
+	})
+	InputMaxDelay = 200 * time.Millisecond
+	InputMinDelay = 0
+
+	data := PingDelaySet{
+		newPingDelay("192.0.2.1", 4, 50*time.Millisecond),
+		newPingDelay("192.0.2.2", 4, 100*time.Millisecond),
+		newPingDelay("192.0.2.3", 3, 80*time.Millisecond),
+		newPingDelay("192.0.2.4", 3, 250*time.Millisecond),
+		newPingDelay("192.0.2.5", 2, 70*time.Millisecond),
+	}
+	sort.Sort(data)
+
+	got := data.FilterDelay()
+	want := map[string]bool{
+		"192.0.2.1": true,
+		"192.0.2.2": true,
+		"192.0.2.3": true,
+		"192.0.2.5": true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("FilterDelay() returned %d entries, want %d", len(got), len(want))
+	}
+	for _, item := range got {
+		if !want[item.IP.String()] {
+			t.Errorf("FilterDelay() unexpectedly returned %s", item.IP)
+		}
+		delete(want, item.IP.String())
+	}
+	for ip := range want {
+		t.Errorf("FilterDelay() omitted eligible IP %s", ip)
+	}
+}
+
+func newPingDelay(ip string, received int, delay time.Duration) CloudflareIPData {
+	return CloudflareIPData{PingData: &PingData{
+		IP:       &net.IPAddr{IP: net.ParseIP(ip)},
+		Sended:   4,
+		Received: received,
+		Delay:    delay,
+	}}
+}


### PR DESCRIPTION
## 问题描述

延迟测速结果是先按照丢包率从低到高排序，丢包率相同时，再按照平均延迟从低到高排序。

但`FilterDelay`遇到第一个超过平均延迟上限的节点时会直接退出循环。这错误地假设了后续所有节点的平均延迟一定更高。

例如，设置平均延迟上限为200 ms，排序后的数据如下：

| 丢包率 | 平均延迟 | 是否满足延迟条件 |
|---:|---:|---|
| 0% | 50 ms | 是 |
| 0% | 100 ms | 是 |
| 25% | 80 ms | 是 |
| 25% | 250 ms | 否 |
| 50% | 70 ms | 是 |

旧逻辑处理到`25% / 250 ms`时会执行`break`，因此不会继续检查后面的`50% / 70 ms`节点。

最终旧逻辑只返回前三个满足条件的节点，错误遗漏了同样满足延迟上限的`50% / 70 ms`节点。

## 修复方式

将平均延迟超过上限时的处理从退出整个循环改为只跳过当前节点，这样`FilterDelay`会检查所有丢包率分组，并保留每个分组中满足平均延迟条件的节点。

## 测试

新增回归测试 `TestFilterDelayChecksEveryLossRateGroup`，使用上述跨丢包率分组的 mock 数据验证过滤结果。

在旧逻辑下运行：

```text
=== RUN   TestFilterDelayChecksEveryLossRateGroup
    csv_test.go:35: FilterDelay() returned 3 entries, want 4
--- FAIL: TestFilterDelayChecksEveryLossRateGroup
```

应用修复后运行同一测试：

```text
=== RUN   TestFilterDelayChecksEveryLossRateGroup
--- PASS: TestFilterDelayChecksEveryLossRateGroup
PASS
```

另外已运行完整测试和竞态检查：

```bash
go test ./...
go test -race ./...
```