### PR TITLE
fix: 修复HTTP状态码校验逻辑（&&改为||）

### DIFF
--- a/task/httping.go
+++ b/task/httping.go
@@ -61,7 +61,7 @@ func (p *Ping) httping(ip *net.IPAddr) (int, time.Duration, string) {
 
 		//fmt.Println("IP:", ip, "StatusCode:", response.StatusCode, response.Request.URL)
 		// 如果未指定的 HTTP 状态码，或指定的状态码不合规，则默认只认为 200、301、302 才算 HTTPing 通过
-		if HttpingStatusCode == 0 || HttpingStatusCode < 100 && HttpingStatusCode > 599 {
+		if HttpingStatusCode == 0 ||  HttpingStatusCode < 100 || HttpingStatusCode > 599 {
 			if response.StatusCode != 200 && response.StatusCode != 301 && response.StatusCode != 302 {
 				if utils.Debug { // 调试模式下，输出更多信息
 					utils.Red.Printf("[调试] IP: %s, 延迟测速终止，HTTP 状态码: %d, 测速地址: %s\n", ip.String(), response.StatusCode, URL)


### PR DESCRIPTION
大佬好，提个小 PR。

`-httping-code` 这个参数的校验条件是：
`HttpingStatusCode < 100 && HttpingStatusCode > 599`
`&&` 是“与”，一个数不可能同时小于100又大于599，所以这个条件永远为 false。

这就导致如果用户指定了一个不合规的状态码（比如 `-httping-code 99`），程序不会回退到默认的 200/301/302，而是拿 99 去比对，所有 IP 都会失败。

改成 `||` 就行了：
`HttpingStatusCode < 100 || HttpingStatusCode > 599`

改完之后测过，`-httping-code 99` 正常回退，`-httping-code 200` 行为不变。
只改了一个字符，没别的影响。

辛苦大佬帮忙看下，谢谢！